### PR TITLE
fix: remove last whitespace in pokemon names in generated json

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,9 +44,10 @@ func main() {
 	// Find and visit all links
 	c.OnHTML(".pokemonname", func(e *colly.HTMLElement) {
 		s := strings.Split(e.Text, ".")
+		name := s[1]
 		p := Pokemon{
 			Id:   s[0],
-			Name: s[1],
+			Name: s[1][0 : len(name)-1],
 		}
 		pokemons = append(pokemons, p)
 	})


### PR DESCRIPTION
이름 마지막에 들어가는 whitespace 를 없애는 작업입니다.